### PR TITLE
Only handle velocity messages

### DIFF
--- a/scripts/publisher.py
+++ b/scripts/publisher.py
@@ -49,20 +49,22 @@ def getData():
 	oldJson = raw_data[1]
 	raw_data = raw_data[0]
 	return raw_data
-	
+
 
 def publisher():
 	pub_raw = rospy.Publisher('dvl/json_data', String, queue_size=10)
 	pub = rospy.Publisher('dvl/data', DVL, queue_size=10)
-	
+
 	rate = rospy.Rate(10) # 10hz
 	while not rospy.is_shutdown():
 		raw_data = getData()
 		if do_log_raw_data:
 			rospy.loginfo(raw_data)
 		data = json.loads(raw_data)
+		if data["type"] != "velocity":
+			continue
 		pub_raw.publish(raw_data)
-		
+
 		theDVL.header.stamp = rospy.Time.now()
 		theDVL.header.frame_id = "dvl_link"
 		theDVL.time = data["time"]
@@ -74,39 +76,39 @@ def publisher():
 		theDVL.velocity_valid = data["velocity_valid"]
 		theDVL.status = data["status"]
 		theDVL.form = data["format"]
-		
+
 		beam0.id = data["transducers"][0]["id"]
 		beam0.velocity = data["transducers"][0]["velocity"]
 		beam0.distance = data["transducers"][0]["distance"]
 		beam0.rssi = data["transducers"][0]["rssi"]
 		beam0.nsd = data["transducers"][0]["nsd"]
 		beam0.valid = data["transducers"][0]["beam_valid"]
-		
+
 		beam1.id = data["transducers"][1]["id"]
 		beam1.velocity = data["transducers"][1]["velocity"]
 		beam1.distance = data["transducers"][1]["distance"]
 		beam1.rssi = data["transducers"][1]["rssi"]
 		beam1.nsd = data["transducers"][1]["nsd"]
 		beam1.valid = data["transducers"][1]["beam_valid"]
-		
+
 		beam2.id = data["transducers"][2]["id"]
 		beam2.velocity = data["transducers"][2]["velocity"]
 		beam2.distance = data["transducers"][2]["distance"]
 		beam2.rssi = data["transducers"][2]["rssi"]
 		beam2.nsd = data["transducers"][2]["nsd"]
 		beam2.valid = data["transducers"][2]["beam_valid"]
-		
+
 		beam3.id = data["transducers"][3]["id"]
 		beam3.velocity = data["transducers"][3]["velocity"]
 		beam3.distance = data["transducers"][3]["distance"]
 		beam3.rssi = data["transducers"][3]["rssi"]
 		beam3.nsd = data["transducers"][3]["nsd"]
 		beam3.valid = data["transducers"][3]["beam_valid"]
-		
+
 		theDVL.beams = [beam0, beam1, beam2, beam3]
-		
+
 		pub.publish(theDVL)
-		
+
 		rate.sleep()
 
 if __name__ == '__main__':


### PR DESCRIPTION
Dead reckoning messages, introduced in a DVL software release over the
summer, will be ignored; previously, they were leading to a parsing
error.